### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/dt/dt_requirements.txt
+++ b/dt/dt_requirements.txt
@@ -73,7 +73,7 @@ protobuf==4.24.4
 psutil==5.9.6
 pure-eval==0.2.2
 pyarrow==13.0.0
-pyautogen==0.1.11
+ag2==0.1.11
 pycodestyle==2.11.1
 pycparser==2.21
 pydantic==2.4.2

--- a/gma/gma_requirements.txt
+++ b/gma/gma_requirements.txt
@@ -73,7 +73,7 @@ protobuf==4.24.4
 psutil==5.9.6
 pure-eval==0.2.2
 pyarrow==13.0.0
-pyautogen==0.1.11
+ag2==0.1.11
 pycodestyle==2.11.1
 pycparser==2.21
 pydantic==2.4.2

--- a/notebooks/groupchat.ipynb
+++ b/notebooks/groupchat.ipynb
@@ -20,7 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install pyautogen"
+    "! pip install ag2"
    ]
   },
   {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
